### PR TITLE
abbrevs: Change `plz` to `pls` and `thx` to `tks` (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## [Unreleased]
+
+### Breaking changes
+
+- Changed `plz` to `pls` and `thx` to `tks`
+
+## [0.1.0] - 2025-08-04
+
+Initial release!
+
+[unreleased]: https://github.com/langston-barrett/lesshand/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/langston-barrett/lesshand/releases/tag/v0.1.0

--- a/crates/lib/src/abbrev.rs
+++ b/crates/lib/src/abbrev.rs
@@ -15,6 +15,10 @@ pub(crate) fn char_is_valid_in_abbrev_tgt(b: u8) -> bool {
 }
 
 // TODO:
+// abbrev!("language", "lang"),
+// abbrev!("sorry", "sry"),
+// abbrev!("family", "fam"),
+// abbrev!("better", "btr"),
 // abbrev!("business", "biz"),
 // abbrev!("including", "incl"),
 // abbrev!("universty", "uni"),
@@ -36,7 +40,6 @@ pub(crate) fn char_is_valid_in_abbrev_tgt(b: u8) -> bool {
 // abbrev!("in real life", ",irl"),
 // abbrev!("oh my god", ",omg"),
 // abbrev!("on the other hand", ",otoh"),
-// abbrev!("sorry", "sry"),
 // abbrev!("to be announced", ",tba"),
 // abbrev!("to be decided", ",tbd"),
 //
@@ -94,12 +97,12 @@ pub const ABBREVS: &[(&str, &str, u64)] = &[
     abbrev!("only", "oy"),
     abbrev!("otherwise", "othw"),
     abbrev!("over", "ov"),
-    abbrev!("please", "plz"),
+    abbrev!("please", "pls"),
     abbrev!("really", "rly"),
     abbrev!("several", "sev"),
     abbrev!("shouldn't", "sd'"),
     abbrev!("should", "sd"),
-    abbrev!("thanks", "thx"),
+    abbrev!("thanks", "tks"),
     abbrev!("that", "tt"),
     abbrev!("the", "l"),
     abbrev!("they", "e"),

--- a/crates/lib/src/ambiguity.rs
+++ b/crates/lib/src/ambiguity.rs
@@ -115,6 +115,7 @@ mod test {
             I've --> iv: 602
             good --> gd: 598
             million --> mil: 558
+            please --> pls: 528
             October --> oct: 504
         "#]];
         let mut results = Vec::with_capacity(ABBREVS.len());

--- a/crates/lib/src/effort/qwerty.rs
+++ b/crates/lib/src/effort/qwerty.rs
@@ -712,12 +712,12 @@ mod test_qwerty_effort {
             only --> oy: 5
             otherwise --> othw: 14
             over --> ov: 6
-            please --> plz: 7
+            please --> pls: 8
             really --> rly: 7
             several --> sev: 10
             shouldn't --> sd': 16
             should --> sd: 10
-            thanks --> thx: 6
+            thanks --> tks: 7
             that --> tt: 5
             the --> l: 6
             they --> e: 8

--- a/crates/lib/src/mem.rs
+++ b/crates/lib/src/mem.rs
@@ -176,12 +176,12 @@ mod test {
             only --> oy: 8
             otherwise --> othw: 7
             over --> ov: 7
-            please --> plz: 0
+            please --> pls: 9
             really --> rly: 9
             several --> sev: 9
             shouldn't --> sd': 16
             should --> sd: 8
-            thanks --> thx: 0
+            thanks --> tks: 9
             that --> tt: 8
             the --> l: 0
             they --> e: 1

--- a/crates/lib/src/reqs.rs
+++ b/crates/lib/src/reqs.rs
@@ -206,8 +206,8 @@ fn check_memorable(abbrevs: &[(&str, &str)]) -> Result<(), RequirementError> {
         ("having", "hvq"),
         ("I've", "iv"),
         ("okay", "k"),
-        ("please", "plz"),
-        ("thanks", "thx"),
+        ("please", "pls"),
+        ("thanks", "tks"),
     ];
     const MIN_MEMORABILITY: usize = 5;
     for (long, short) in abbrevs.iter().copied() {
@@ -259,7 +259,7 @@ fn check_uniquely_memorable(abbrevs: &[(&str, &str)]) -> Result<(), RequirementE
         ("not", "x"),
         ("of", "o"),
         ("okay", "k"), // ok: existing
-        ("please", "plz"),
+        ("please", "pls"),
         ("should", "sd"),
         ("thanks", "thx"),
         ("that", "tt"),
@@ -342,12 +342,14 @@ fn check_uniquely_memorable(abbrevs: &[(&str, &str)]) -> Result<(), RequirementE
     const SPECIFIC_WORD_EXCEPTIONS: &[(&str, &str, &str)] = &[
         ("also", "al", "all"),
         ("billion", "bil", "bill"),
-        ("must", "mt", "meet"), // also has "mustn't"
-        ("must", "mt", "met"),  // also has "mustn't"
+        ("must", "mt", "meet"),    // also has "mustn't"
+        ("must", "mt", "met"),     // also has "mustn't"
+        ("please", "pls", "plus"), // ok: existing
         ("president", "pres", "press"),
         ("rights", "rts", "rates"),
         ("several", "sev", "seven"),
         ("something", "smth", "smith"),
+        ("thanks", "tks", "takes"), // ok: existing
         ("will", "ll", "little"),
     ];
     for (i0, (long0, short)) in abbrevs.iter().copied().enumerate() {

--- a/crates/lib/src/score.rs
+++ b/crates/lib/src/score.rs
@@ -123,15 +123,15 @@ mod test {
             international --> intl: 69
             okay --> k: 69
             major --> mjr: 68
+            please --> pls: 66
+            thanks --> tks: 64
             department --> dept: 53
             especially --> esp: 53
             move --> mv: 52
             services --> svcs: 44
             interest --> ist: 40
             market --> mkt: 34
-            please --> plz: 28
             rights --> rts: 24
-            thanks --> thx: 24
             baby --> bb: 22
             littlest --> lilst: 0
             internationally --> intlly: 0

--- a/doc/abbrevs.md
+++ b/doc/abbrevs.md
@@ -65,12 +65,12 @@ okay --> k
 only --> oy
 otherwise --> othw
 over --> ov
-please --> plz
+please --> pls
 really --> rly
 several --> sev
 shouldn't --> sd'
 should --> sd
-thanks --> thx
+thanks --> tks
 that --> tt
 the --> l
 they --> e


### PR DESCRIPTION
Fixes #7.